### PR TITLE
FUL-44313: updated Realm to fix C++ assertions when usign Realm KMM

### DIFF
--- a/FrameworkGenerator/Podfile
+++ b/FrameworkGenerator/Podfile
@@ -6,8 +6,8 @@ inhibit_all_warnings!
 target 'Dummy' do
   target 'SwiftLibs' do
       pod 'RxBlocking', '~> 6.5.0'
-      pod 'Realm', '~> 10.39.1'
-      pod 'RealmSwift', '~> 10.39.1'
+      pod 'Realm', '~> 10.40.1'
+      pod 'RealmSwift', '~> 10.40.1'
       pod 'RxSwift', '~> 6.5.0'
       pod 'RxCocoa', '~> 6.5.0'
       pod 'RxTest', '~> 6.5.0'

--- a/FrameworkGenerator/Podfile.lock
+++ b/FrameworkGenerator/Podfile.lock
@@ -135,11 +135,11 @@ PODS:
     - PubNub/Core (= 4.17.0)
   - PubNub/Core (4.17.0)
   - QRCodeReaderViewController (4.0.2)
-  - Realm (10.39.1):
-    - Realm/Headers (= 10.39.1)
-  - Realm/Headers (10.39.1)
-  - RealmSwift (10.39.1):
-    - Realm (= 10.39.1)
+  - Realm (10.40.2):
+    - Realm/Headers (= 10.40.2)
+  - Realm/Headers (10.40.2)
+  - RealmSwift (10.40.2):
+    - Realm (= 10.40.2)
   - RxBlocking (6.5.0):
     - RxSwift (= 6.5.0)
   - RxCocoa (6.5.0):
@@ -196,8 +196,8 @@ DEPENDENCIES:
   - PromiseKit/UIKit (~> 6.8.3)
   - PubNub (~> 4.17.0)
   - QRCodeReaderViewController (~> 4.0.2)
-  - Realm (~> 10.39.1)
-  - RealmSwift (~> 10.39.1)
+  - Realm (~> 10.40.1)
+  - RealmSwift (~> 10.40.1)
   - RxBlocking (~> 6.5.0)
   - RxCocoa (~> 6.5.0)
   - RxSwift (~> 6.5.0)
@@ -266,8 +266,8 @@ SPEC CHECKSUMS:
   PromiseKit: 9616b0afef31eae56ab9ce044c8ec2b8612a15cd
   PubNub: 306896876c3089884067609ff25d628a547d2942
   QRCodeReaderViewController: e8f27d035b3e72b1d4b1c61ff66458287e3be0ff
-  Realm: 1f3157edf145f4d9036765ab550c8cb18f62b700
-  RealmSwift: 8a69a1cb788cd5865966f49667b130567e07bceb
+  Realm: 731e86d9388287b18e36b0beb2493fc4845ce8a2
+  RealmSwift: c2a1059ba52e1e08467b1253b1d4ab354ef3177b
   RxBlocking: 04b5fd28bb5ea49f7d64b80db8bbfe50d9cc1c7d
   RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
   RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
@@ -277,6 +277,6 @@ SPEC CHECKSUMS:
   Themes: d3810257315e54a035691c204aa40a92f2f1085b
   TransformerKit: 1295d491e9999960afdedcb0a163489827efd169
 
-PODFILE CHECKSUM: 51437cf9ea3e50423dd87ba10571ff7233060810
+PODFILE CHECKSUM: f6cefae1c7c8be6fcbf2b12403f5976632a84fde
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.11.3


### PR DESCRIPTION
### Context

Within [FUL-44313](https://beekeeper.atlassian.net/browse/FUL-44313) we are working on adding persistence layer into the shared code in KMM. We decided to go with Realm KMM.

### Details

When we added Realm KMM into the https://github.com/beekpr/clients-multiplatform-base/pull/38 we started to see C++ assertion when running iOS code which interacts with Realm:

![image-2](https://github.com/beekpr/ios-binaries/assets/2588925/57bfd023-32c6-4b2f-a6e9-7771440c7316)

On the other hand when we created a sample iOS + KMM project there were no such problems.

It turns out that we simply had to update Realm  to version `10.40.2` which is aligned with Realm KMM that we plan to use within https://github.com/beekpr/clients-multiplatform-base. With that we have added new Swift libs release `Swift-5.9-v2`.


[FUL-44313]: https://beekeeper.atlassian.net/browse/FUL-44313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ